### PR TITLE
Fix broken links

### DIFF
--- a/codegen-java/README.adoc
+++ b/codegen-java/README.adoc
@@ -121,5 +121,5 @@ This helps ensure that Pkl files are valid as part of a project's test.
 
 == Further Resources
 
-* https://pkl-lang.org/main/current/pkl-codegen-java/[pkl-codegen-java documentation]
+* https://pkl-lang.org/main/current/java-binding/codegen[pkl-codegen-java documentation]
 * https://pkl-lang.org/main/current/pkl-gradle/[Gradle plugin documentation]

--- a/codegen-kotlin/README.adoc
+++ b/codegen-kotlin/README.adoc
@@ -89,5 +89,5 @@ with `evaluator.evaluate(ModuleSource.path("path/to/config.pkl"))`.
 
 == Further Resources
 
-* https://pkl-lang.org/main/current/pkl-codegen-kotlin/[pkl-codegen-kotlin documentation]
+* https://pkl-lang.org/main/current/kotlin-binding/codegen[pkl-codegen-kotlin documentation]
 * https://pkl-lang.org/main/current/pkl-gradle/[Gradle plugin documentation]

--- a/config-java/README.adoc
+++ b/config-java/README.adoc
@@ -8,4 +8,4 @@ TIP:: See the xref:../codegen-java/README.adoc[codegen-java] example for how to 
 
 == Further Resources
 
-* https://pkl-lang.org/main/current/pkl-config-java/[pkl-config-java documentation]
+* https://pkl-lang.org/main/current/java-binding/pkl-config-java[pkl-config-java documentation]

--- a/config-kotlin/README.adoc
+++ b/config-kotlin/README.adoc
@@ -8,4 +8,4 @@ TIP:: See the xref:../codegen-kotlin/README.adoc[codegen-kotlin] example for how
 
 == Further Resources
 
-* https://pkl-lang.org/main/current/pkl-config-kotlin/[pkl-config-kotlin documentation]
+* https://pkl-lang.org/main/current/kotlin-binding/pkl-config-kotlin[pkl-config-kotlin documentation]


### PR DESCRIPTION
Some links in the documentation were broken, leading to `Page Not Found`.
This pull requests fixes those errors. 